### PR TITLE
Show playtime while gaming with music

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -632,9 +632,24 @@ document.addEventListener('DOMContentLoaded', () => {
         const artist = musicData.artist && musicData.artist !== 'Unknown' ? musicData.artist : 'Unknown Artist';
         setDualLabels('gamepad-2', gameName, 'music', artist);
 
-        // Show song title as hint when playing both
-        const title = musicData.title && musicData.title !== 'Not Playing' ? musicData.title : 'Unknown Track';
-        renderHintLines([], title);
+        // Show song title and playtime when playing both
+        const hintLines = [];
+        const trackLine = getTrackLine(musicData);
+        if (trackLine) {
+          hintLines.push({ icon: 'music-2', text: trackLine });
+        }
+
+        const playtime = calculatePlaytime(gameData.start_time);
+        if (playtime) {
+          hintLines.push({ icon: 'timer', text: `Playing for ${playtime}` });
+        }
+
+        if (hintLines.length > 0) {
+          renderHintLines(hintLines);
+        } else {
+          const title = musicData.title && musicData.title !== 'Not Playing' ? musicData.title : 'Unknown Track';
+          renderHintLines([], title);
+        }
       } else {
         setLabel('gamepad-2', gameName);
 


### PR DESCRIPTION
## Summary
- display both the current track and the game session duration when music plays alongside a game
- fall back to the previous single-line hint if no track info is available

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cc063e85e883289a1aaa1b3a2b954d