### PR TITLE
Improve activity widget mobile layout

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -539,6 +539,8 @@ button {
 .widget-shell__artwork {
   width: 128px;
   height: 128px;
+  max-width: 100%;
+  aspect-ratio: 1 / 1;
   border-radius: 24px;
   background: var(--accent-soft);
   border: 1px solid var(--border);
@@ -565,7 +567,8 @@ button {
   flex-direction: column;
   gap: 0.25rem;
   align-items: center;
-  justify-content: center;\n  position: relative;
+  justify-content: center;
+  position: relative;
   text-align: center;
   min-width: 0;
   flex: 1;
@@ -659,7 +662,10 @@ button {
   gap: 0.35rem;
   align-items: center;
   text-align: center;
-  min-height: 2.4rem;\n  max-height: 2.4rem;\n  overflow: hidden;\n  justify-content: flex-start;
+  min-height: 2.4rem;
+  max-height: 2.4rem;
+  overflow: hidden;
+  justify-content: flex-start;
 }
 
 /* Hide hint when empty but keep the space for proper centering */
@@ -687,7 +693,7 @@ button {
   min-height: 1.1rem;
   text-align: center;
 }
-\n
+
 
 .widget-shell__hint-line i {
   color: var(--text-muted);
@@ -703,7 +709,7 @@ button {
   width: 100%;
   height: 100%;
 }
-\n
+
 
 .widget-shell__hint-line span:last-child {
   flex: 1;
@@ -714,7 +720,7 @@ button {
   white-space: nowrap;
   max-width: 100%;
 }
-\n
+
 
 .site__footer {
   padding-top: 0.5rem;
@@ -1073,16 +1079,18 @@ button {
   .widget-shell {
     grid-template-columns: 1fr;
     gap: 1rem;
+    justify-items: center;
   }
 
   .widget-shell__artwork {
-    width: 100%;
-    height: 80px;
+    width: min(160px, 70vw);
+    height: auto;
     justify-self: center;
   }
 
   .widget-shell__meta {
     gap: 0.6rem;
+    width: 100%;
   }
 
   .widget-shell__meta--with-hint {

--- a/static/js/site.js
+++ b/static/js/site.js
@@ -313,8 +313,14 @@ document.addEventListener('DOMContentLoaded', () => {
     const calculatePlaytime = (startTime) => {
       if (!startTime) return null;
 
+      const numericStart = Number(startTime);
+      if (!Number.isFinite(numericStart)) return null;
+
+      // Some providers return milliseconds instead of seconds.
+      const startInSeconds = numericStart > 1e12 ? Math.floor(numericStart / 1000) : numericStart;
+
       const now = Math.floor(Date.now() / 1000); // Current time in seconds
-      const elapsed = now - startTime; // Elapsed time in seconds
+      const elapsed = Math.floor(Math.max(0, now - startInSeconds)); // Clamp to avoid negative durations
 
       if (elapsed < 60) {
         return `${elapsed}s`;


### PR DESCRIPTION
## Summary
- keep the activity widget artwork square and tighten the mobile layout so the card centers correctly on smaller screens
- clean up widget metadata spacing to avoid hint/label collisions on mobile
- clamp activity playtime calculations so negative durations are no longer displayed

## Testing
- None


------
https://chatgpt.com/codex/tasks/task_e_68cc066792f08328855aa5dabacf9f8a