### PR TITLE
Allow page to scroll on shorter viewports

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -73,8 +73,8 @@ body[data-theme='light'] {
 html,
 body {
   margin: 0;
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  overflow-x: hidden;
 }
 
 body {
@@ -85,6 +85,7 @@ body {
   position: relative;
   display: flex;
   justify-content: center;
+  min-height: 100vh;
 }
 
 a {
@@ -202,7 +203,7 @@ button {
   padding: 1.5rem 2rem;
   display: grid;
   grid-template-rows: auto 1fr auto;
-  height: 100vh;
+  min-height: 100vh;
   gap: 1.5rem;
 }
 


### PR DESCRIPTION
## Summary
- allow the page to scroll by default while keeping horizontal overflow hidden
- use min-height instead of fixed heights so the layout expands on shorter desktop windows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc06d3de808328ad8d2523aa0b7d4c